### PR TITLE
Added pipeline.yaml

### DIFF
--- a/.harness/Pipeline.yaml
+++ b/.harness/Pipeline.yaml
@@ -1,0 +1,86 @@
+pipeline:
+  name: testk8s
+  identifier: testk8s
+  projectIdentifier: communityeng
+  orgIdentifier: default
+  tags: {}
+  stages:
+    - stage:
+        name: k8deploy
+        identifier: k8deploy
+        description: ""
+        type: Deployment
+        spec:
+          serviceConfig:
+            serviceRef: k8service
+            serviceDefinition:
+              spec:
+                variables: []
+                manifests:
+                  - manifest:
+                      identifier: manifest
+                      type: K8sManifest
+                      spec:
+                        store:
+                          type: Github
+                          spec:
+                            connectorRef: testhelp
+                            gitFetchType: Branch
+                            paths:
+                              - default-k8s-manifests/Manifests/Files/templates
+                            repoName: harness-docs
+                            branch: main
+                        skipResourceVersioning: false
+                  - manifest:
+                      identifier: values
+                      type: Values
+                      spec:
+                        store:
+                          type: Github
+                          spec:
+                            connectorRef: testhelp
+                            gitFetchType: Branch
+                            paths:
+                              - default-k8s-manifests/Manifests/Files/ng_values_dockercfg.yaml
+                            repoName: harness-docs
+                            branch: main
+                artifacts:
+                  primary:
+                    spec:
+                      connectorRef: harnessdocker
+                      imagePath: <+input>
+                      tag: <+input>
+                    type: DockerRegistry
+              type: Kubernetes
+          infrastructure:
+            environmentRef: K8Env
+            infrastructureDefinition:
+              type: KubernetesDirect
+              spec:
+                connectorRef: test
+                namespace: default
+                releaseName: release-<+INFRA_KEY>
+            allowSimultaneousDeployments: false
+          execution:
+            steps:
+              - step:
+                  name: Rollout Deployment
+                  identifier: rolloutDeployment
+                  type: K8sRollingDeploy
+                  timeout: 10m
+                  spec:
+                    skipDryRun: false
+            rollbackSteps:
+              - step:
+                  name: Rollback Rollout Deployment
+                  identifier: rollbackRolloutDeployment
+                  type: K8sRollingRollback
+                  timeout: 10m
+                  spec: {}
+        tags: {}
+        failureStrategies:
+          - onFailure:
+              errors:
+                - AllErrors
+              action:
+                type: StageRollback


### PR DESCRIPTION
Started with adding the pipeline.yaml to CD sample, it's placed under .harness folder to enable usage of git-experience from harness platform

Signed-off-by: debabrata.panigrahi@harness.io